### PR TITLE
FEAT: Lyrics Web Scraping functionality as alternative to hard-coded

### DIFF
--- a/tools.py
+++ b/tools.py
@@ -1,6 +1,10 @@
 import os
 from math import floor
 import random
+# These 3 modules below need to be imported for web/regex functionality
+import requests # for http/https curls (get)
+from bs4 import BeautifulSoup # html parsing/web scraping tool
+import re # Regular Expression (RegEx) tools
 
 #file variable used in menuFunction and chooseFile
 filename = ""
@@ -246,7 +250,22 @@ def rickAstley(filename):
         data = f.read(100)
         if len(data) > 0:
             f.write("\n")
-        lyrics = """We're no strangers to love
+        # Adding optional download from Internet/Web scraping
+        # vs. hard-coded lyrics of Rick Astley's song
+        # Edits: John R. Hampton (Github - Grok42)
+        getweb = input("Do you want to download lyrics from the internet?: \n")
+        if re.match('(Y|y)',getweb):
+            # My URL is the lyrics copy & pasted into my Poetry/Lit Hobbycraft site
+            url = "https://www.deviantart.com/maggotsx/art/Never-Gonna-Give-You-Up-916069850" 
+            r = requests.get(url)
+            soup = BeautifulSoup(r.content, 'html5lib')
+            lyrics = soup.find_all('span', {'class':re.compile('.*public-DraftStyleDefault-ltr')})
+            for line in lyrics:
+                rickroll = re.sub('\<[^\>\<]+\>','',str(line))    
+                f.write(rickroll + "\n")
+        else:
+            # Else, Continue with original hard-coded lyrics
+            lyrics = """We're no strangers to love
 You know the rules and so do I
 A full commitment's what I'm thinking of
 You wouldn't get this from any other guy
@@ -277,7 +296,7 @@ Never gonna make you cry
 Never gonna say goodbye
 Never gonna tell a lie and hurt you
 """
-        f.write(lyrics)
+            f.write(lyrics)
         f.close
 
 


### PR DESCRIPTION
FEAT: Added Lyrics Web Scraping functionality as alternative to hard-coded.

Hi James, the Rick Roll (Lyrics to File) function in [main/tools.py](https://github.com/bajuba/FileProcessingFunctionsTool/blob/main/tools.py) gave me a chuckle so I thought I'd add something. Not sure if this repo is WIP or a leftover from a previous semester. Might get some mileage out of the modules I imported for future classes though.

I already had most of the script edits written since I've been using similar do web scrap DeviantArt pages and archive my web-based Poetry/Lit hobbycraft submissions to file. Dread eventually losing access to DeviantArt and the 350+ Literature submissions I've made. Need to get offline copies zipped up. DevArt is a big site though so not worried overly much about it going under.

Basically, just copied/edited existing script and then copy/pasted lyrics into a DeviantArt Lit Submission.

The new tools.py script is web-scrapping that. You can find it at this URL below (and in the code)... 
[Never-Gonna-Give-You-Up](https://www.deviantart.com/maggotsx/art/Never-Gonna-Give-You-Up-916069850)

I do have my DeviantArt credentials stored on my PCs browers but the script addition works from console. Haven't tested it on a PC that has never signed in to Deviant Art. So if Deviant Art stores some kind of device authentication on their servers and uses that, the script may not pull (curl) everything it needs. Let me know if there are issues. I'll give it a go on my PC downstairs (never logged in to DA) later.

Looking forward to our Zoom.

Best Regards,
John Hampton